### PR TITLE
Update run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -12,6 +12,9 @@ from statistics import Statistics
 from bilibili import bilibili
 import threading
 import biliconsole
+import io , sys
+sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding='utf-8')
+sys.stderr = io.TextIOWrapper(sys.stderr.detach(), encoding='utf-8')
 
 
 loop = asyncio.get_event_loop()


### PR DESCRIPTION
解决在英文系统下的编码问题，导致 run.py 无法直接运行
之前英文系统运行需要通过指定编码 PYTHONIOENCODING=utf-8 python3 run.py