### PR TITLE
增加Docker支持

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.6-alpine
+
+ENV LIBRARY_PATH=/lib:/usr/lib \
+    USER_NAME='' \
+    USER_PASSWORD=''
+
+WORKDIR /app
+
+RUN apk add --no-cache --virtual bili git build-base python-dev py-pip jpeg-dev zlib-dev && \
+    git clone https://github.com/Dawnnnnnn/bilibili-live-tools.git /app && \
+    pip install --no-cache-dir -r requirements.txt && \
+    rm -r /var/cache/apk && \
+    rm -r /usr/share/man && \
+    apk del bili
+
+ENTRYPOINT sed -i ''"$(cat conf/bilibili.conf -n | grep "username =" | awk '{print $1}')"'c '"$(echo "username = ${USER_NAME}")"'' conf/bilibili.conf && \
+            sed -i ''"$(cat conf/bilibili.conf -n | grep "password =" | awk '{print $1}')"'c '"$(echo "password = ${USER_PASSWORD}")"'' conf/bilibili.conf && \
+            python ./run.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.6-alpine
 
+MAINTAINER zsnmwy <szlszl35622@gmail.com>
+
 ENV LIBRARY_PATH=/lib:/usr/lib \
     USER_NAME='' \
     USER_PASSWORD=''


### PR DESCRIPTION
已经发布在了[DockerHub](https://hub.docker.com/r/zsnmwy/bilibili-live-tools/)

在DockerHub的镜像大小为 38M。

用法

```
docker pull zsnmwy/bilibili-live-tools

docker run -itd -e USER_NAME=B站登陆账户 -e USER_PASSWORD=登陆密码 --name 容器名字(随意) zsnmwy/bilibili-live-tools

```

```
相关参数

-it  # 不后台

-itd # 后台
```

---

为了能及时更新镜像，最好就是可以在dockerhub那边部署下自动构建。



