### PR TITLE
Adapt to captain monitor

### DIFF
--- a/OnlineHeart.py
+++ b/OnlineHeart.py
@@ -40,44 +40,41 @@ class OnlineHeart:
             Printer().printer("连接舰长服务器失败", "Error", "red")
             return
         for i in range(0, len(json_response)):
-            if json_response[i]['Status']:
-                GuardId = json_response[i]['GuardId']
-                if GuardId not in had_gotted_guard and GuardId != 0:
-                    had_gotted_guard.append(GuardId)
-                    OriginRoomId = json_response[i]['OriginRoomId']
-                    if not OriginRoomId == OnlineHeart.last_guard_room:
-                        result = await utils.check_room_true(OriginRoomId)
-                        if True in result:
-                            Printer().printer(f"检测到房间 {OriginRoomId} 的钓鱼操作", "Warning", "red")
-                            continue
-                        await bilibili().post_watching_history(OriginRoomId)
-                        OnlineHeart.last_guard_room = OriginRoomId
-                    response2 = await bilibili().get_gift_of_captain(OriginRoomId, GuardId)
-                    json_response2 = await response2.json(content_type=None)
-                    if json_response2['code'] == 0:
-                        Printer().printer(f"获取到房间 {OriginRoomId} 编号 {GuardId} 的上船亲密度: {json_response2['data']['message']}",
-                                          "Lottery", "cyan")
-                    elif json_response2['code'] == 400 and json_response2['msg'] == "你已经领取过啦":
-                        Printer().printer(
-                            f"房间 {OriginRoomId} 编号 {GuardId} 的上船亲密度已领过",
-                            "Info", "green")
-                    elif json_response2['code'] == 400 and json_response2['msg'] == "访问被拒绝":
-                        Printer().printer(f"获取房间 {OriginRoomId} 编号 {GuardId} 的上船亲密度: {json_response2['message']}",
-                                          "Lottery", "cyan")
-                        print(json_response2)
-                    else:
-                        Printer().printer(
-                            f"房间 {OriginRoomId} 编号 {GuardId}  的上船亲密度领取出错: {json_response2}",
-                            "Error", "red")
-            else:
-                pass
+            GuardId = json_response[i]['GuardId']
+            if GuardId not in had_gotted_guard and GuardId != 0:
+                had_gotted_guard.append(GuardId)
+                OriginRoomId = json_response[i]['OriginRoomId']
+                if not OriginRoomId == OnlineHeart.last_guard_room:
+                    result = await utils.check_room_true(OriginRoomId)
+                    if True in result:
+                        Printer().printer(f"检测到房间 {OriginRoomId} 的钓鱼操作", "Warning", "red")
+                        continue
+                    await bilibili().post_watching_history(OriginRoomId)
+                    OnlineHeart.last_guard_room = OriginRoomId
+                response2 = await bilibili().get_gift_of_captain(OriginRoomId, GuardId)
+                json_response2 = await response2.json(content_type=None)
+                if json_response2['code'] == 0:
+                    Printer().printer(f"获取到房间 {OriginRoomId} 编号 {GuardId} 的上船亲密度: {json_response2['data']['message']}",
+                                      "Lottery", "cyan")
+                elif json_response2['code'] == 400 and json_response2['msg'] == "你已经领取过啦":
+                    Printer().printer(
+                        f"房间 {OriginRoomId} 编号 {GuardId} 的上船亲密度已领过",
+                        "Info", "green")
+                elif json_response2['code'] == 400 and json_response2['msg'] == "访问被拒绝":
+                    Printer().printer(f"获取房间 {OriginRoomId} 编号 {GuardId} 的上船亲密度: {json_response2['message']}",
+                                      "Lottery", "cyan")
+                    print(json_response2)
+                else:
+                    Printer().printer(
+                        f"房间 {OriginRoomId} 编号 {GuardId}  的上船亲密度领取出错: {json_response2}",
+                        "Error", "red")
 
 
     async def draw_lottery(self):
         black_list = ["123", "1111", "测试", "測試", "测一测", "ce-shi", "test", "T-E-S-T", "lala",  # 已经出现
                       "測一測", "TEST", "Test", "t-e-s-t"]  # 合理猜想
         last_lottery = 0
-        for i in range(295, 400):
+        for i in range(390, 600):
             response = await bilibili().get_lotterylist(i)
             json_response = await response.json()
             if json_response['code'] == 0:

--- a/Tasks.py
+++ b/Tasks.py
@@ -77,13 +77,14 @@ class Tasks:
     async def auto_send_gift(self):
         if self.dic_user['auto-gift']['on/off'] == "1":
             a = await utils.fetch_medal(printer=False)
-            res = await bilibili().gift_list()
-            json_res = await res.json()
-            temp_dic = {}
-            for j in range(0, len(json_res['data'])):
-                price = json_res['data'][j]['price']
-                id = json_res['data'][j]['id']
-                temp_dic[id] = price
+            # res = await bilibili().gift_list()
+            # json_res = await res.json()
+            # temp_dic = {}
+            # for j in range(0, len(json_res['data'])):
+            #     price = json_res['data'][j]['price']
+            #     id = json_res['data'][j]['id']
+            #     temp_dic[id] = price
+            temp_dic = {1: 100, 6: 1000}
             x, temp = await utils.fetch_bag_list(printer=False)
             roomid = a[0]
             today_feed = a[1]
@@ -95,7 +96,7 @@ class Tasks:
                 gift_num = int(temp[i][1])
                 bag_id = int(temp[i][2])
                 expire = int(temp[i][3])
-                if (gift_id != 4 and gift_id != 3 and gift_id != 9 and gift_id != 10) and expire != 0:
+                if gift_id in [1, 6] and expire != 0:
                     if (gift_num * (temp_dic[gift_id] / 100) < left_num):
                         calculate = calculate + temp_dic[gift_id] / 100 * gift_num
                         tmp2 = temp_dic[gift_id] / 100 * gift_num

--- a/bilibili.py
+++ b/bilibili.py
@@ -92,6 +92,10 @@ class bilibili():
                     Printer().printer('403频繁，5s后重试',"Error","red")
                     await asyncio.sleep(5)
                     continue
+                elif response.status == 412:
+                    Printer().printer('412触发风控被拒绝，60s后重试',"Error","red")
+                    await asyncio.sleep(60)
+                    continue
                 tag = await self.replay_request(response)
                 if tag:
                     continue
@@ -109,6 +113,10 @@ class bilibili():
                 if response.status == 403:
                     Printer().printer('403频繁，5s后重试',"Error","red")
                     await asyncio.sleep(5)
+                    continue
+                elif response.status == 412:
+                    Printer().printer('412触发风控被拒绝，60s后重试',"Error","red")
+                    await asyncio.sleep(60)
                     continue
                 tag = await self.replay_request(response)
                 if tag:

--- a/bilibiliCilent.py
+++ b/bilibiliCilent.py
@@ -240,7 +240,7 @@ class bilibiliClient():
         elif cmd in ["NOTICE_MSG", "SYS_MSG"]:
             pass
         # 各种高能 [节奏风暴（开始 结束），高能广播（无抽奖 活动高能 全频风暴），抽奖通知（现在广播全在这里了），总督广播]
-        elif cmd in ["SPECIAL_GIFT", "SYS_GIFT", "SYS_MSG", "GUARD_MSG"]:
+        elif cmd in ["SPECIAL_GIFT", "SYS_GIFT", "SYS_MSG", "GUARD_MSG", "GUIARD_MSG"]:
             pass
         # 礼物效果 [连击开始，连击结束，使用积分加成卡]
         elif cmd in ["COMBO_SEND", "COMBO_END", "SCORE_CARD"]:
@@ -265,15 +265,20 @@ class bilibiliClient():
         # 活动榜单相关 [进入小时榜，未知，获小时榜第一道具奖励]
         elif cmd in ["ROOM_RANK", "new_anchor_reward", "HOUR_RANK_AWARDS"]:
             pass
-        # 活动相关 [活动获得的直播间入场特效，活动事件（如充能值信息），以前的高能事件，送礼抽奖活动开奖，LOL竞猜活动，LOL助力活动]
-        elif cmd in ["WELCOME_ACTIVITY", "ACTIVITY_EVENT", "EVENT_CMD", "BOX_LOTTERY_WIN", "LOL_ACTIVITY", "ACTIVITY_MATCH_GIFT"]:
+        # 活动相关 [活动获得的直播间入场特效，活动事件（如充能值信息），以前的高能事件，送礼抽奖活动开奖，LOL竞猜活动，LOL助力活动，？（不知道是啥，每个直播间都有，无论开播，每分钟发一次），？，？，冲鸭！机甲大作战相关，周星活动相关]
+        elif cmd in ["WELCOME_ACTIVITY", "ACTIVITY_EVENT", "EVENT_CMD", "BOX_LOTTERY_WIN", "LOL_ACTIVITY", "ACTIVITY_MATCH_GIFT",
+                     "ACTIVITY_BANNER_RED_NOTICE_CLOSE", "ACTIVITY_BANNER_CLOSE", "DAILY_QUEST_NEWDAY",
+                     "BOSS_ENERGY", "NOTICE_MSG_H5", "BOSS_INJURY", "BOSS_BATTLE", "ANIMATION", "BOSS_INFO",
+                     "WEEK_STAR_CLOCK", "ROOM_BOX_MASTER", "ROOM_BOX_USER"]:
             pass
-        # 直播间信息相关 [直播间更换壁纸，直播间界面皮肤变化，许愿瓶进度变化，关注数变化，实物抽奖宝箱提醒，实物抽奖宝箱开奖]
-        elif cmd in ["CHANGE_ROOM_INFO", "ROOM_SKIN_MSG", "WISH_BOTTLE", "ROOM_REAL_TIME_MESSAGE_UPDATE", "BOX_ACTIVITY_START", "WIN_ACTIVITY"]:
+        # 直播间信息相关 [直播间更换壁纸，直播间界面皮肤变化，许愿瓶进度变化，关注数变化，直播间更名，实物抽奖宝箱提醒，实物抽奖宝箱开奖，弹幕抽奖结束]
+        elif cmd in ["CHANGE_ROOM_INFO", "ROOM_SKIN_MSG", "WISH_BOTTLE", "ROOM_REAL_TIME_MESSAGE_UPDATE", "ROOM_CHANGE", "BOX_ACTIVITY_START", "WIN_ACTIVITY", "DANMU_LOTTERY_END"]:
             pass
         # 大乱斗活动
-        elif cmd in ["PK_BATTLE_PRE", "PK_BATTLE_START", "PK_BATTLE_PROCESS", "PK_BATTLE_PRO_TYPE", "PK_BATTLE_END", "PK_BATTLE_SETTLE_USER", "PK_BATTLE_SETTLE", "PK_LOTTERY_START"]:
+        elif cmd in ["PK_BATTLE_ENTRANCE", "PK_BATTLE_PRE", "PK_BATTLE_MATCH_TIMEOUT", "PK_BATTLE_START", "PK_BATTLE_VOTES_ADD",
+                     "PK_BATTLE_PROCESS", "PK_BATTLE_PRO_TYPE", "PK_BATTLE_GIFT", "PK_BATTLE_END", "PK_BATTLE_RANK_CHANGE",
+                     "PK_BATTLE_SETTLE_USER", "PK_BATTLE_SETTLE", "PK_LOTTERY_START", "ACTIVITY_BANNER_UPDATE"]:
             pass
         else:
-            Printer().printer(f"出现一个未知msg @[{self.area}分区]{self._roomId} {dic}", "Warning", "red")
+            # Printer().printer(f"出现一个未知msg @[{self.area}分区]{self._roomId} {dic}", "Warning", "red")
             pass


### PR DESCRIPTION
匹配舰长监控返回数据的格式修改
组织上决定自动刷满勋章只送辣条和亿元了，避免各种新礼物gift_id报错
412风控提示
弹幕cmd例行维护
鉴于B站新活动太频繁，暂时取消新cmd的Warning
鉴于验证码服务器修复希望渺茫，增加手动输入验证码的模块
实物抽奖id范围更新