### PR TITLE
解决 aiohttp unclosed client session warning

### DIFF
--- a/bilibili.py
+++ b/bilibili.py
@@ -50,7 +50,7 @@ class bilibili():
             if old_session is not None:
                 await old_session.close()
 
-            # empty future will not end
+            # this continues until program shuts down
             await self.session_keep_alive()
 
     @property


### PR DESCRIPTION
以 async with 格式确保程序终止时 aiohttp (in bilibili.py) 正常关闭