### PR TITLE
在 Ctrl-C 退出 main 的同时结束子进程；移除一行多余代码

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,6 @@ class Auto_Run():
         try:
             while 1:
                 time.sleep(sleep_time * 20)
-                self.poll = self.p.poll()
                 if self.p.poll() is None:
                     print("restarting......")
                     self.p.kill()
@@ -30,6 +29,7 @@ class Auto_Run():
                     print("starting......")
                     self.run()
         except KeyboardInterrupt as e:
+            self.p.kill()
             print("exit???")
 
     def run(self):


### PR DESCRIPTION
原版每次 Ctrl-C 退出时总会有继续输出或跳一堆报错，看了代码才发现是没正常结束子进程。。

还有23行没用到的代码，删掉没关系吧？